### PR TITLE
Fix wrong path separator on Windows

### DIFF
--- a/lua/smart-open/entry/create.lua
+++ b/lua/smart-open/entry/create.lua
@@ -4,7 +4,8 @@ local function calculate_proximity(a, b)
   local previous_index = 1
 
   while true do
-    index = a:find("/", index + 1)
+    local path_separator = package.config:sub(1, 1)
+    index = a:find(path_separator, index + 1)
     if not index then
       break
     elseif index > 1 then

--- a/lua/smart-open/util/virtual_name.lua
+++ b/lua/smart-open/util/virtual_name.lua
@@ -19,7 +19,8 @@ function M.get_pos(path)
   repeat
     penultimate = last
     last = current
-    current, k = path:find("/", k + 1, true)
+    local path_separator = package.config:sub(1, 1)
+    current, k = path:find(path_separator, k + 1, true)
   until current == nil
 
   return is_index_filename[path:sub(last + 1, path:len())] and penultimate + 1 or last + 1


### PR DESCRIPTION
package.config is a string whose first character is the director separtor for the current system: https://www.lua.org/manual/5.3/manual.html#pdf-package.config

Fixes #32

Tested on Windows and Linux.