### PR TITLE
feat: add path separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ require('telescope').extensions.smart_open.smart_open {
 
   Format filename as "filename path/to/parent/directory" if `true` and "path/to/parent/directory/filename" if `false`.
 
+- `space_as_separator` (default: `false`)
+
+  Use space to separator file from folder.  Useful to remove de necessity of `/`.
+
 
 ## Configuration
 

--- a/lua/smart-open/init.lua
+++ b/lua/smart-open/init.lua
@@ -18,6 +18,7 @@ return {
     set_config("ignore_patterns", ext_config.ignore_patterns)
     set_config("match_algorithm", ext_config.match_algorithm)
     set_config("cwd_only", ext_config.cwd_only)
+    set_config("space_as_separator", ext_config.space_as_separator)
 
     config.db_filename = vim.fn.stdpath("data") .. "/smart_open.sqlite3"
 
@@ -25,4 +26,3 @@ return {
     history:setup(db, config)
   end,
 }
-

--- a/lua/telescope/_extensions/smart_open/picker.lua
+++ b/lua/telescope/_extensions/smart_open/picker.lua
@@ -42,6 +42,26 @@ function M.start(opts)
   picker = pickers.new(opts, {
     prompt_title = "Search Files By Name",
     on_input_filter_cb = function(query_text)
+      if opts.space_as_separator and opts.filename_first then
+        local first_space_pos = query_text:find(" ")
+
+        if first_space_pos then
+          local before_space = query_text:sub(1, first_space_pos)
+          local after_space = query_text:sub(first_space_pos + 1)
+          query_text = before_space .. after_space:gsub(" ", "/")
+        end
+      elseif opts.space_as_separator then
+        -- Find the position of the last space
+        local last_space_pos = query_text:match(".*()%s")
+
+        -- If a space is found, replace all other spaces with slashes
+        if last_space_pos then
+          local before_last_space = query_text:sub(1, last_space_pos - 1)
+          local after_last_space = query_text:sub(last_space_pos + 1)
+          query_text = "/" .. before_last_space:gsub(" ", "/") .. " " .. after_last_space
+        end
+      end
+
       return { prompt = query_text }
     end,
     attach_mappings = function(_, map)


### PR DESCRIPTION
Fixes: https://github.com/danielfalk/smart-open.nvim/issues/45

when filename_first:
search for: "ky app ch ap" turns into "ky app/ch/ap"

when not filename_first:
search for "app ch ap ky" turns into "app/ch/ap ky"