### PR TITLE
feat: add `SmartOpenDirectory` highlight group

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,6 @@ As a result, files added to git, _but also ignored by git_, will not be included
 
 ### Highlight Groups
 
-```vim
-Directory
-```
-
-
+| Highlight Group    | Links to  |
+| ------------------ | --------- |
+| SmartOpenDirectory | Directory |

--- a/lua/smart-open/init.lua
+++ b/lua/smart-open/init.lua
@@ -10,6 +10,8 @@ local function set_config(opt_name, value)
   end
 end
 
+vim.cmd("highlight default link SmartOpenDirectory Directory")
+
 return {
   config = config,
   setup = function(ext_config)

--- a/lua/telescope/_extensions/smart_open/display/format_filepath.lua
+++ b/lua/telescope/_extensions/smart_open/display/format_filepath.lua
@@ -81,7 +81,7 @@ local function format_filepath(path, filename, opts, maxlen)
       result = filename .. spacing .. fit_dir(path, remaining, { shorten_to = 8 })
     end
     local start_index = len(filename .. spacing)
-    hl_group = { { start_index, start_index + len(result) }, "Directory" }
+    hl_group = { { start_index, start_index + len(result) }, "SmartOpenDirectory" }
 
     return result, hl_group
   else
@@ -96,7 +96,7 @@ local function format_filepath(path, filename, opts, maxlen)
         -- There's just enough space for the filename
         return filename, hl_group
       elseif remaining == 2 then
-        return "…/" .. filename, { { 1, 2 }, "Directory" }
+        return "…/" .. filename, { { 1, 2 }, "SmartOpenDirectory" }
       end
 
       path = fit_dir(path, remaining, { shorten_to = 0 })
@@ -104,7 +104,7 @@ local function format_filepath(path, filename, opts, maxlen)
     if path ~= "" then
       path = path .. "/"
     end
-    hl_group = { { 0, len(path) }, "Directory" }
+    hl_group = { { 0, len(path) }, "SmartOpenDirectory" }
     return path .. filename, hl_group
   end
 end


### PR DESCRIPTION
Adds a new highlight group to replace the default `Directory` group.

The new `SmartOpenDirectory` group allows users to override the color of the directory in smart-open without changing the main `Directory` group.

### Why?

My other pickers look like this:
![image](https://github.com/danielfalk/smart-open.nvim/assets/39483124/6b0257ac-6943-4bfc-a2de-8ae454470223)

With the current highlighting configuration, smart-open looks like this:
![image](https://github.com/danielfalk/smart-open.nvim/assets/39483124/fa077cd7-8a1c-44b2-a4e8-55152824ab9b)

With the proposed changes, I can make it look like this instead:
![image](https://github.com/danielfalk/smart-open.nvim/assets/39483124/aff24a64-abc9-4ccf-a22a-67a37bab58a7)
