### PR TITLE
Options no_ignore, no_ignore_parent, hidden and follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,21 @@ See [default configuration](https://github.com/nvim-telescope/telescope.nvim#tel
 - `result_limit` (default: `40`)
 
   Limit the number of results returned.  Note that this is kept intentionally low by default for performance.  The main goal of this plugin is to be able to jump to the file you want with very few keystrokes.  Smart open should put relevant results at your fingertips without having to waste time typing too much or scanning through a long list of results.  If you need to scan regardless, go ahead and increase this limit.  However, if better search results would make that unnecessary and there's a chance that smart open could provide them, please [file a bug](https://github.com/danielfalk/smart-open.nvim/issues/new) to help make it better.
+- `follow` (default: `false`)
+
+    If true, follows symlinks (i.e. uses `-L` flag for the `rg` command)
+
+- `hidden` (default: `false`)
+
+    Determines whether to show hidden files or not
+
+- `no_ignore` (default: `false`)
+
+    Show files ignored by .gitignore, .ignore, etc.
+
+- `no_ignore_parent` (default: `false`)
+
+    Show files ignored by .gitignore, .ignore, etc. in parent dirs.
 
 ### Example Configuration:
 
@@ -218,12 +233,6 @@ telescope.setup {
 }
 
 ```
-
-### Known Limitations
-
-For files not already in your history, smart-open uses ripgrep for scanning the current directory.  (The command is roughly: `rg --files --glob-case-insensitive --hidden --ignore-file=<cwd>/.ff-ignore -g <ignore_patterns...>`).
-
-As a result, files added to git, _but also ignored by git_, will not be included.  While not common, this is something that git allows. If this becomes a problem you can work around it by either changing your git ignore patterns, editing the file in neovim in some other way, (thereby adding it to the history), or by using ripgrep's `.ignore` file for overriding git.
 
 ### Highlight Groups
 

--- a/lua/smart-open/init.lua
+++ b/lua/smart-open/init.lua
@@ -23,6 +23,10 @@ return {
     set_config("buffer_indicators", ext_config.buffer_indicators)
     set_config("mappings", ext_config.mappings)
     set_config("result_limit", ext_config.result_limit)
+    set_config("hidden", ext_config.hidden)
+    set_config("no_ignore", ext_config.no_ignore)
+    set_config("no_ignore_parent", ext_config.no_ignore_parent)
+    set_config("follow", ext_config.follow)
 
     config.db_filename = vim.fn.stdpath("data") .. "/smart_open.sqlite3"
 

--- a/lua/telescope/_extensions/smart_open/default_config.lua
+++ b/lua/telescope/_extensions/smart_open/default_config.lua
@@ -69,4 +69,8 @@ return {
     previous = "•",
     others = "∘",
   },
+  no_ignore = false,
+  no_ignore_parent = false,
+  follow = false,
+  hidden = false,
 }

--- a/lua/telescope/_extensions/smart_open/finder/finder.lua
+++ b/lua/telescope/_extensions/smart_open/finder/finder.lua
@@ -45,7 +45,7 @@ return function(history, opts, context)
 
   local h = { frecency = 0, recent_rank = 0 }
 
-  file_scanner(opts.cwd, opts.ignore_patterns, function(fullpath)
+  file_scanner(opts, function(fullpath)
     if not is_added[fullpath] then
       local entry_data = create_entry_data(fullpath, h, context)
       match_runner.add_entry(entry_data)

--- a/lua/telescope/_extensions/smart_open/picker.lua
+++ b/lua/telescope/_extensions/smart_open/picker.lua
@@ -38,6 +38,10 @@ function M.start(opts)
     show_scores = vim.F.if_nil(opts.show_scores, config.show_scores),
     match_algorithm = opts.match_algorithm or config.match_algorithm,
     result_limit = vim.F.if_nil(opts.result_limit, config.result_limit),
+    no_ignore = vim.F.if_nil(opts.no_ignore, config.no_ignore),
+    no_ignore_parent = vim.F.if_nil(opts.no_ignore_parent, config.no_ignore_parent),
+    follow = vim.F.if_nil(opts.follow, config.follow),
+    hidden = vim.F.if_nil(opts.hidden, config.hidden),
   }, context)
   opts.get_status_text = finder.get_status_text
 


### PR DESCRIPTION
Add options no_ignore, no_ignore_parent, hidden and follow

These four options are brought from the find_files finder of Telescope.
Default option for no_ignore is false therefore unlike the current behaviour
all files from .gitignore will be ignored (as it is always done with Telescope
and massively improve performance)
