### PR TITLE
Use synchronous=NORMAL on sqlite

### DIFF
--- a/lua/telescope/_extensions/smart_open/dbclient.lua
+++ b/lua/telescope/_extensions/smart_open/dbclient.lua
@@ -30,7 +30,7 @@ function DbClient:new(o)
       self:initialize_db()
     end
   end
-
+  self.db:eval([[ PRAGMA synchronous = NORMAL ]])
   return o
 end
 

--- a/lua/telescope/_extensions/smart_open/dbclient.lua
+++ b/lua/telescope/_extensions/smart_open/dbclient.lua
@@ -31,6 +31,7 @@ function DbClient:new(o)
     end
   end
   self.db:eval([[ PRAGMA synchronous = NORMAL ]])
+  self.db:eval([[ PRAGMA journal_mode = WAL ]])
   return o
 end
 


### PR DESCRIPTION
`record_usage` and `save_weights` take a combined 30ms on my system. By setting synchronous = NORMAL and enabling WAL, this gets reduced to 3ms. https://www.sqlite.org/pragma.html#pragma_synchronous. 

There may be some other pragmas worth tuning to improve read performance as well 