### PR TITLE
Add default.nix to index file names

### DIFF
--- a/lua/smart-open/util/virtual_name.lua
+++ b/lua/smart-open/util/virtual_name.lua
@@ -9,6 +9,7 @@ local is_index_filename = {
   ["index.test.tsx"] = true,
   ["__init__.py"] = true,
   ["init.lua"] = true,
+  ["default.nix"] = true,
 }
 
 local M = {}


### PR DESCRIPTION
`default.nix` in nix is like `init.lua` in lua.

https://nix.dev/manual/nix/2.18/language/builtins.html?highlight=default.nix#builtins-import