### PR TITLE
add symlink follow support to file_scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Options can be set when opening the picker.  For example:
 require('telescope').extensions.smart_open.smart_open {
   cwd_only = true,
   filename_first = false,
+  follow_symlinks = false,
 }
 ```
 
@@ -175,6 +176,10 @@ require('telescope').extensions.smart_open.smart_open {
 - `filename_first` (default: `true`)
 
   Format filename as "filename path/to/parent/directory" if `true` and "path/to/parent/directory/filename" if `false`.
+
+- `follow_symlinks` (default: `false`)
+
+  Follow symlinks (beware of loops or deep trees).  If the tree doesn't loop and isn't too deep this can be useful in certain repositories.
 
 
 ## Configuration
@@ -202,6 +207,8 @@ See [default configuration](https://github.com/nvim-telescope/telescope.nvim#tel
 - `open_buffer_indicators` (default: `{previous = "•", others = "∘"}`)
 
 - `result_limit` (default: `40`)
+
+- `follow_symlinks` (default: `false`)
 
   Limit the number of results returned.  Note that this is kept intentionally low by default for performance.  The main goal of this plugin is to be able to jump to the file you want with very few keystrokes.  Smart open should put relevant results at your fingertips without having to waste time typing too much or scanning through a long list of results.  If you need to scan regardless, go ahead and increase this limit.  However, if better search results would make that unnecessary and there's a chance that smart open could provide them, please [file a bug](https://github.com/danielfalk/smart-open.nvim/issues/new) to help make it better.
 

--- a/lua/telescope/_extensions/smart_open/default_config.lua
+++ b/lua/telescope/_extensions/smart_open/default_config.lua
@@ -69,4 +69,5 @@ return {
     previous = "•",
     others = "∘",
   },
+  follow_symlinks = false,
 }

--- a/lua/telescope/_extensions/smart_open/file_scanner.lua
+++ b/lua/telescope/_extensions/smart_open/file_scanner.lua
@@ -49,7 +49,7 @@ local function spawn(cmd, opts, input, onexit)
   return stop
 end
 
-local function ripgrep_scan(basedir, ignore_patterns, on_insert, on_complete)
+local function ripgrep_scan(basedir, ignore_patterns, follow_symlinks, on_insert, on_complete)
   local stderr = ""
   local args = {
     "--files",
@@ -59,6 +59,10 @@ local function ripgrep_scan(basedir, ignore_patterns, on_insert, on_complete)
     "--ignore-file",
     basedir .. "/.ff-ignore",
   }
+
+  if follow_symlinks then
+    table.insert(args, "--follow")
+  end
 
   for _, value in ipairs(ignore_patterns) do
     table.insert(args, "-g")
@@ -99,8 +103,8 @@ local function ripgrep_scan(basedir, ignore_patterns, on_insert, on_complete)
   end)
 end
 
-return function(cwd, ignore_patterns, on_insert, on_complete)
-  ripgrep_scan(cwd, ignore_patterns, on_insert, function(exit_code, err)
+return function(cwd, ignore_patterns, on_insert, on_complete, follow_symlinks)
+  ripgrep_scan(cwd, ignore_patterns, follow_symlinks, on_insert, function(exit_code, err)
     if exit_code ~= 0 then
       print("ripgrep exited with code", exit_code, "and error:", err)
     end

--- a/lua/telescope/_extensions/smart_open/finder/finder.lua
+++ b/lua/telescope/_extensions/smart_open/finder/finder.lua
@@ -52,7 +52,7 @@ return function(history, opts, context)
     end
   end, function()
     match_runner.entries_complete()
-  end)
+  end, opts.follow_symlinks)
 
   return setmetatable({
     close = function() end,

--- a/lua/telescope/_extensions/smart_open/picker.lua
+++ b/lua/telescope/_extensions/smart_open/picker.lua
@@ -38,6 +38,7 @@ function M.start(opts)
     show_scores = vim.F.if_nil(opts.show_scores, config.show_scores),
     match_algorithm = opts.match_algorithm or config.match_algorithm,
     result_limit = vim.F.if_nil(opts.result_limit, config.result_limit),
+    follow_symlinks = vim.F.if_nil(opts.follow_symlinks, config.follow_symlinks),
   }, context)
   opts.get_status_text = finder.get_status_text
 


### PR DESCRIPTION
I use a monorepo with symlinks sometimes for certain projects (unity sharing code etc).

This option is dangerous but helpful.