### PR TITLE
fix issues/70

### DIFF
--- a/lua/telescope/_extensions/smart_open/file_scanner.lua
+++ b/lua/telescope/_extensions/smart_open/file_scanner.lua
@@ -57,6 +57,7 @@ local function ripgrep_scan(basedir, ignore_patterns, on_insert, on_complete)
     "--line-buffered",
     "--hidden",
     "--ignore-file",
+    "--path-separator=/",
     basedir .. "/.ff-ignore",
   }
 
@@ -100,6 +101,7 @@ local function ripgrep_scan(basedir, ignore_patterns, on_insert, on_complete)
 end
 
 return function(cwd, ignore_patterns, on_insert, on_complete)
+  cwd = vim.fs.normalize(cwd)
   ripgrep_scan(cwd, ignore_patterns, on_insert, function(exit_code, err)
     if exit_code ~= 0 then
       print("ripgrep exited with code", exit_code, "and error:", err)

--- a/lua/telescope/_extensions/smart_open/finder/finder.lua
+++ b/lua/telescope/_extensions/smart_open/finder/finder.lua
@@ -32,6 +32,7 @@ return function(history, opts, context)
         frecency = v.score / max_score,
         recent_rank = v.recent_rank,
       }
+      v.path = vim.fs.normalize(v.path)
       local entry_data = create_entry_data(v.path, history_data, context)
       entry_data.virtual_name = virtual_name.get_virtual_name(v.path)
 


### PR DESCRIPTION
Changes are done without understanding most of this plugin. I found a hack to make it work but I'm sure there is a better way to do it that I don't know of.

Explanations of the bug can be found on my message here: https://github.com/danielfalk/smart-open.nvim/issues/70#issuecomment-2582802814

Maybe the flag on ripgrep is enough and the `vim.fs.normalize` are only here because my sqlite3 is infected with bad file path ?
Right now, it doesn't work if I don't keep the `vim.fs.normalize`. Some directories are half normalized and half not, which may come from a data provider I am not aware of.
I haven't fully tested properly my changes, maybe there are data paths that do not go through a normalize call and in that case it could fail like previously