### PR TITLE
fix(validate): delete non-exist file

### DIFF
--- a/lua/telescope/_extensions/smart_open/dbclient.lua
+++ b/lua/telescope/_extensions/smart_open/dbclient.lua
@@ -136,7 +136,7 @@ end
 function DbClient:validate()
   local files = self.db:select("files")
   for _, result in ipairs(files) do
-    if util.fs_stat(result.path).exists then
+    if not util.fs_stat(result.path).exists then
       self.db:delete("files", { where = { path = result.path } })
     end
   end


### PR DESCRIPTION
I believe this is a typo. I created a user command myself to valid using this function and unexpectedly deleted all my history files, because I don't like to run `uv.fs_state` for each entry which is very slow when first opening the picker.