### PR TITLE
feat: track buffer line numbers and switch to grep previewer

### DIFF
--- a/lua/smart-open/entry/create.lua
+++ b/lua/smart-open/entry/create.lua
@@ -65,6 +65,7 @@ local function create_entry_data(path, history, context)
     if loaded then
       if loaded.bufnr then
         entry.buf = loaded.bufnr
+        entry.lnum = loaded.lnum
         entry.modified = loaded.is_modified
       end
       scores.open = weights.open

--- a/lua/smart-open/util/virtual_name.lua
+++ b/lua/smart-open/util/virtual_name.lua
@@ -10,6 +10,7 @@ local is_index_filename = {
   ["__init__.py"] = true,
   ["init.lua"] = true,
   ["default.nix"] = true,
+  ["package.d"] = true,
 }
 
 local M = {}

--- a/lua/telescope/_extensions/smart_open/buffers.lua
+++ b/lua/telescope/_extensions/smart_open/buffers.lua
@@ -5,7 +5,8 @@ local function get_buffer_list()
     if vim.fn.buflisted(buf) == 1 and vim.api.nvim_buf_get_name(buf) ~= "" then
       result[vim.api.nvim_buf_get_name(buf)] = {
         bufnr = buf,
-        is_modified = vim.api.nvim_buf_get_option(buf, "modified")
+        is_modified = vim.api.nvim_buf_get_option(buf, "modified"),
+        lnum = vim.fn.getbufinfo(buf)[1].lnum,
       }
     end
   end

--- a/lua/telescope/_extensions/smart_open/picker.lua
+++ b/lua/telescope/_extensions/smart_open/picker.lua
@@ -88,7 +88,7 @@ function M.start(opts)
       return true
     end,
     finder = finder,
-    previewer = telescope_config.file_previewer(opts),
+    previewer = telescope_config.grep_previewer(opts),
     sorter = sorters.Sorter:new({
       -- Just reverse the relevance values for sorting
       scoring_function = function(_, _, x)


### PR DESCRIPTION
This PR improves buffer file previewing in the Smart Open Telescope extension to match the behavior of the default Telescope buffer picker.

Previously, when previewing file buffers, the preview always started from line 1, ignoring the buffer’s current active line. With this change, the preview now opens at the buffer’s current active line, reflecting the last known cursor position.


https://github.com/user-attachments/assets/bf38f751-b372-4ca1-a4cd-9f006af69268


